### PR TITLE
Fix resume pdf open path

### DIFF
--- a/src/windows/Resume/index.js
+++ b/src/windows/Resume/index.js
@@ -9,7 +9,7 @@ pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/$
 export default function Resume() {
 
     const handlePrint = () => {
-        window.open("./Chang_Jeremy_Resume.pdf");
+        window.open(resume);
     };
 
     return (


### PR DESCRIPTION
## Summary
- open resume pdf using imported asset path

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472bd3504083259f9c122647219246