### PR TITLE
Fix engineering label

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -15,7 +15,7 @@ const projects = {
 };
 
 const engineering = {
-    label: "Engineer Projects",
+    label: "Engineering Projects",
     header: "Engineering Projects",
     desktopIcon: require(`../assets/engineering.png`),
     desktopPosition: 3,


### PR DESCRIPTION
## Summary
- rename engineering window label to "Engineering Projects" for consistency

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472ebb06f48325be5a89ef416be51f