### PR TITLE
Wrap global listeners in effect

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,8 +33,14 @@ function AppWrapper() {
     [focused, setFocused, currentButtons]
   );
 
-  document.addEventListener("click", handleClick);
-  document.addEventListener("touchstart", handleClick);
+  React.useEffect(() => {
+    document.addEventListener("click", handleClick);
+    document.addEventListener("touchstart", handleClick);
+    return () => {
+      document.removeEventListener("click", handleClick);
+      document.removeEventListener("touchstart", handleClick);
+    };
+  }, [handleClick]);
 
   return <><Desktop /></>;
 }


### PR DESCRIPTION
## Summary
- remove direct `addEventListener` calls
- register the global listeners inside `useEffect`
- cleanup the listeners on unmount

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472ebc1b448325a4999e04668601bb